### PR TITLE
remove csu22_summit1 remnants

### DIFF
--- a/qsub_summit
+++ b/qsub_summit
@@ -328,7 +328,6 @@ def main():
     parser.add_argument('-a','--account',type=str,choices=ACCOUNTS_LIST,default=ACCOUNTS_LIST[0],help='Account to submit job to')
     parser.add_argument('-m', '--mail', type=str, choices=MAIL_ACCEPT, help='Send email upon given condition')
     parser.add_argument('-n', '--nproc', type=int, default=24, help='Number of cpus to use per node')
-    parser.add_argument('--proj', action="store_true", default=False, help='Use a special project account')
     parser.add_argument('--nnode', type=int, default=1, help='Number of nodes')
     parser.add_argument('--version', type=str, default='current', help='Request old version of Gaussian [b01 = B.01] or Orca [v401 = 4.0.1, v412 = 4.1.2], v420 = 4.2.0')
     parser.add_argument('--code', type=str, default='xtb', help='Request crest, xtb, or enso code routines')
@@ -357,11 +356,8 @@ def main():
 
         account = args.account
         if args.qos == 'condo': #use rsp account
-            account = ACCOUNTS_LIST[2]
-            print("Condo QOS requested, using {} account".format(account))
-        if args.proj == True:  #use csu22 account
             account = ACCOUNTS_LIST[1]
-            print("Projects account requested, using {} account".format(account))
+            print("Condo QOS requested, using {} account".format(account))
         # use testing partition with testing qos
         if args.partition == 'shas-testing':
             args.qos = 'testing'
@@ -373,13 +369,6 @@ def main():
             if args.partition not in PARTITION_ACCEPT[0:6]:
                 err = ('Error: partition {0} cannot be used with account {1}\n'
                 'csu-general may use the following partitions:'.format(args.partition,account))
-                print(err)
-                print(PARTITION_ACCEPT[0:6])
-                sys.exit(1)
-        elif account is ACCOUNTS_LIST[2]: #csu22_summit1
-            if args.partition not in PARTITION_ACCEPT[0:6]:
-                err = ('Error: partition {0} cannot be used with account {1}\n'
-                'csu22_summit1 may use the following partitions:'.format(args.partition,account))
                 print(err)
                 print(PARTITION_ACCEPT[0:6])
                 sys.exit(1)


### PR DESCRIPTION
Prevent conflicts when submitting accounts by removing leftover pieces of the option for csu22_summit1 (which is no longer active) 